### PR TITLE
Add note on guacamole's listen location for non-nginx configuration.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@
 #   to   - 8080:8080/tcp
 #  within the 'guacamole' service. This will expose the guacamole webinterface directly
 #  on port 8080 and you can use it for your own purposes.
+#  Do note, guacamole is available on :8080/guacamole, not /.
 #
 # !!!!! FOR INITAL SETUP (after git clone) run ./prepare.sh once
 #
@@ -135,7 +136,7 @@ services:
       guacnetwork_compose:
     ports:
 ## enable next line if not using nginx
-##    - 8080:8080/tcp
+##    - 8080:8080/tcp # Guacamole is on :8080/guacamole, not /.
 ## enable next line when using nginx
     - 8080/tcp
     restart: always


### PR DESCRIPTION
Closes #13 

Not going to add anything to README at this time.

I shall pardon myself for being extraordinarily mad. I needed a minimal, and maintainable docker setup. It was just magic how with the nginx setup, everything worked, yet when copy-pastaing everything in to docker host, it didn't. To add to the confusion, initdb and data needed to be cleared and re-generated on some edge cases.
To add to the confusion, tomahawk listens on / as well, so it wasn't that I got a 404/timeout, etc.

There was so much duplicate and unneeded text for my case, I would've preferred a docker-compose.yml file with minimal comments, and a 10 line readme. I think I would've been able to figure it out on my own, if there wasn't the commented 'if use with other revproxy', what was partially true. /shrug

