### PR TITLE
Update postgres service to work with selinux and fix #34

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,13 +109,13 @@ services:
       POSTGRES_DB: guacamole_db
       POSTGRES_PASSWORD: 'ChooseYourOwnPasswordHere1234'
       POSTGRES_USER: guacamole_user
-    image: postgres:13.4
+    image: postgres:13.4-buster
     networks:
       guacnetwork_compose:
     restart: always
     volumes:
-    - ./init:/docker-entrypoint-initdb.d:ro
-    - ./data:/var/lib/postgresql/data:rw
+    - ./init:/docker-entrypoint-initdb.d:z
+    - ./data:/var/lib/postgresql/data:Z
 
   # guacamole
   guacamole:


### PR DESCRIPTION
- Use z and Z modes in palce of ro and rw modes on volumes
- Use postgres:13.4-buster due to docker-library/postgres issue #884

Signed-off-by: Malcolm VanOrder <mvanorder1390@gmail.com>