### PR TITLE
Modifications to fix WOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,18 @@ Your guacamole server should now be available at `https://ip of your server:8443
 To understand some details let's take a closer look at parts of the `docker-compose.yml` file:
 
 ### Networking
-The following part of docker-compose.yml will create a network with name `guacnetwork_compose` in mode `bridged`.
+The following part of docker-compose.yml will create a network with name `guacnetwork_compose`.
 ~~~python
 ...
 # networks
-# create a network 'guacnetwork_compose' in mode 'bridged'
 networks:
   guacnetwork_compose:
-    driver: bridge
 ...
 ~~~
 
 ### Services
 #### guacd
-The following part of docker-compose.yml will create the guacd service. guacd is the heart of Guacamole which dynamically loads support for remote desktop protocols (called "client plugins") and connects them to remote desktops based on instructions received from the web application. The container will be called `guacd_compose` based on the docker image `guacamole/guacd` connected to our previously created network `guacnetwork_compose`. Additionally we map the 2 local folders `./drive` and `./record` into the container. We can use them later to map user drives and store recordings of sessions.
+The following part of docker-compose.yml will create the guacd service. guacd is the heart of Guacamole which dynamically loads support for remote desktop protocols (called "client plugins") and connects them to remote desktops based on instructions received from the web application. The container will be called `guacd_compose` based on the docker image `guacamole/guacd` connected to the host network to allow for low-level features such as WOL. Additionally we map the 2 local folders `./drive` and `./record` into the container. We can use them later to map user drives and store recordings of sessions.
 
 ~~~python
 ...
@@ -47,8 +45,7 @@ services:
   guacd:
     container_name: guacd_compose
     image: guacamole/guacd
-    networks:
-      guacnetwork_compose:
+    network_mode: host # connect to host to allow WOL to work
     restart: always
     volumes:
     - ./drive:/drive:rw
@@ -89,7 +86,7 @@ The following part of docker-compose.yml will create an instance of guacamole by
     - guacd
     - postgres
     environment:
-      GUACD_HOSTNAME: guacd
+      GUACD_HOSTNAME: 172.17.0.1 # docker's bridge gateway
       POSTGRES_DATABASE: guacamole_db
       POSTGRES_HOSTNAME: postgres
       POSTGRES_PASSWORD: ChooseYourOwnPasswordHere1234
@@ -120,7 +117,7 @@ The following part of docker-compose.yml will create an instance of nginx that m
    - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
    - ./nginx/mysite.template:/etc/nginx/conf.d/default.conf:ro
    ports:
-   - 8443:443
+   - 8443:443 # change to an available external port
    links:
    - guacamole
    networks:
@@ -144,10 +141,6 @@ by nginx for https.
 
 ## reset.sh
 To reset everything to the beginning, just run `./reset.sh`.
-
-## WOL
-
-Wake on LAN (WOL) does not work and I will not fix that because it is beyound the scope of this repo. But [zukkie777](https://github.com/zukkie777) who also filed [this issue](https://github.com/boschkundendienst/guacamole-docker-compose/issues/12) fixed it. You can read about it on the [Guacamole mailing list](http://apache-guacamole-general-user-mailing-list.2363388.n4.nabble.com/How-to-docker-composer-for-WOL-td9164.html)
 
 **Disclaimer**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@
 # 0.3                2017-10-09        minor fixes + public GIT push
 # 0.4                2019-08-14        creating of ssl certs now in prepare.sh
 #                                      simplified nginx startup commands
+# 0.5                2022-09-23        move guacd to host network to get WOL working
 ####################################################################################
 
 version: '2.0'
@@ -150,7 +151,7 @@ services:
    - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
    - ./nginx/mysite.template:/etc/nginx/conf.d/default.conf:ro
    ports:
-   - 9443:443 # change to an available external port
+   - 8443:443 # change to an available external port
    links:
    - guacamole
    networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@
 #
 # Using docker-compose it will:
 #
-# - create a network 'guacnetwork_compose' with the 'bridge' driver.
-# - create a service 'guacd_compose' from 'guacamole/guacd' connected to 'guacnetwork'
+# - create a network 'guacnetwork_compose'
+# - create a service 'guacd_compose' from 'guacamole/guacd' connected to the host network
 # - create a service 'postgres_guacamole_compose' (1) from 'postgres' connected to 'guacnetwork'
 # - create a service 'guacamole_compose' (2)  from 'guacamole/guacamole/' conn. to 'guacnetwork'
 # - create a service 'nginx_guacamole_compose' (3) from 'nginx' connected to 'guacnetwork'
@@ -84,10 +84,8 @@
 version: '2.0'
 
 # networks
-# create a network 'guacnetwork_compose' in mode 'bridged'
 networks:
   guacnetwork_compose:
-    driver: bridge
 
 # services
 services:
@@ -95,8 +93,7 @@ services:
   guacd:
     container_name: guacd_compose
     image: guacamole/guacd
-    networks:
-      guacnetwork_compose:
+    network_mode: host # connect to host to allow WOL to work
     restart: always
     volumes:
     - ./drive:/drive:rw
@@ -124,7 +121,7 @@ services:
     - guacd
     - postgres
     environment:
-      GUACD_HOSTNAME: guacd
+      GUACD_HOSTNAME: 172.17.0.1 # docker's bridge gateway
       POSTGRES_DATABASE: guacamole_db
       POSTGRES_HOSTNAME: postgres
       POSTGRES_PASSWORD: 'ChooseYourOwnPasswordHere1234'
@@ -153,7 +150,7 @@ services:
    - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
    - ./nginx/mysite.template:/etc/nginx/conf.d/default.conf:ro
    ports:
-   - 8443:443
+   - 9443:443 # change to an available external port
    links:
    - guacamole
    networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@
 #
 # Using docker-compose it will:
 #
-# - create a network 'guacnetwork_compose'
-# - create a service 'guacd_compose' from 'guacamole/guacd' connected to the host network
+# - create a network 'guacnetwork_compose' with the 'bridge' driver.
+# - create a service 'guacd_compose' from 'guacamole/guacd' connected to host for WOL
 # - create a service 'postgres_guacamole_compose' (1) from 'postgres' connected to 'guacnetwork'
 # - create a service 'guacamole_compose' (2)  from 'guacamole/guacamole/' conn. to 'guacnetwork'
 # - create a service 'nginx_guacamole_compose' (3) from 'nginx' connected to 'guacnetwork'
@@ -79,14 +79,16 @@
 # 0.3                2017-10-09        minor fixes + public GIT push
 # 0.4                2019-08-14        creating of ssl certs now in prepare.sh
 #                                      simplified nginx startup commands
-# 0.5                2022-09-23        move guacd to host network to get WOL working
+# 0.5                2022-10-01        move guacd to host network to get WOL working
 ####################################################################################
 
 version: '2.0'
 
 # networks
+# create a network 'guacnetwork_compose' in mode 'bridged'
 networks:
   guacnetwork_compose:
+    driver: bridge
 
 # services
 services:
@@ -94,7 +96,7 @@ services:
   guacd:
     container_name: guacd_compose
     image: guacamole/guacd
-    network_mode: host # connect to host to allow WOL to work
+    network_mode: host
     restart: always
     volumes:
     - ./drive:/drive:rw
@@ -121,8 +123,10 @@ services:
     depends_on:
     - guacd
     - postgres
+    extra_hosts:
+    - host.docker.internal:host-gateway
     environment:
-      GUACD_HOSTNAME: 172.17.0.1 # docker's bridge gateway
+      GUACD_HOSTNAME: host.docker.internal
       POSTGRES_DATABASE: guacamole_db
       POSTGRES_HOSTNAME: postgres
       POSTGRES_PASSWORD: 'ChooseYourOwnPasswordHere1234'
@@ -151,7 +155,7 @@ services:
    - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
    - ./nginx/mysite.template:/etc/nginx/conf.d/default.conf:ro
    ports:
-   - 8443:443 # change to an available external port
+   - 8443:443
    links:
    - guacamole
    networks:


### PR DESCRIPTION
These are some simple network modifications to get the Guacamole features of sending WOL packets to function. WOL magic packets are low-level packets that are not supported by the standard docker networking, so the easiest and least-painful fix is to move guacd to the host network.

Big thanks to @tonytvbg who provided his fix for https://github.com/boschkundendienst/guacamole-docker-compose/issues/12