### PR TITLE
[scripts] Create all needed directories

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -8,6 +8,9 @@ then
 fi
 echo "Preparing folder init and creating ./init/initdb.sql"
 mkdir ./init >/dev/null 2>&1
+mkdir ./data >/dev/null 2>&1
+mkdir ./drive >/dev/null 2>&1
+mkdir ./record >/dev/null 2>&1
 mkdir -p ./nginx/ssl >/dev/null 2>&1
 chmod -R +x ./init
 docker run --rm guacamole/guacamole /opt/guacamole/bin/initdb.sh --postgresql > ./init/initdb.sql


### PR DESCRIPTION
On Synology Docker, the docker-compose config fails to find these directories.

The error looks like:
```
ERROR: for guacamole  Cannot start service guacamole: Bind mount failed: '/volume1/@docker/drive' does not exists
```

This change makes sure that when ./prepare.sh is run, all needed directories exist.