### PR TITLE
add watchdog to monitor and restart services on failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@
 # - create a service 'guacd_compose' from 'guacamole/guacd' connected to 'guacnetwork_compose'
 # - create a service 'postgres_guacamole_compose' (1) from 'postgres' connected to 'guacnetwork_compose'
 # - create a service 'guacamole_compose' (2)  from 'guacamole/guacamole/' conn. to 'guacnetwork_compose'
-# - create a service 'nginx_guacamole_compose' (3) from 'nginx' connected to 'guacnetwork_compose'
+# - create a service 'watchdog_guacamole_compose' (3)  from 'docker:cli' to monitor the health
+# - create a service 'nginx_guacamole_compose' (4) from 'nginx' connected to 'guacnetwork_compose'
 #
 # (1)
 #  DB-Init script is in './init/initdb.sql' it has been created executing
@@ -144,12 +145,28 @@ services:
       - guacnetwork_compose
     volumes:
       - ./record:/record:rw
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/guacamole/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     ports:
 ## enable next line if not using nginx
 ##    - 8080:8080/tcp # Guacamole is on :8080/guacamole, not /.
 ## enable next line when using nginx
     - 8080/tcp
     restart: always
+
+  # watchdog
+  watchdog:
+    image: docker:cli
+    container_name: watchdog_guacamole_compose
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./watchdog.sh:/watchdog.sh:ro
+    entrypoint: ["sh", "/watchdog.sh"]
 
 ########### optional ##############
   # nginx
@@ -161,6 +178,12 @@ services:
    - ./nginx/templates:/etc/nginx/templates:ro
    - ./nginx/ssl/self.cert:/etc/nginx/ssl/self.cert:ro
    - ./nginx/ssl/self-ssl.key:/etc/nginx/ssl/self-ssl.key:ro
+   healthcheck:
+     test: ["CMD", "curl", "-k", "-f", "https://localhost:443/"]
+     interval: 30s
+     timeout: 10s
+     retries: 3
+     start_period: 40s
    ports:
    - 8443:443
    networks:

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Find any container with the compose label to get the project name
+container_id=$(docker ps --filter "label=com.docker.compose.project" --format '{{.ID}}' | head -n 1)
+
+if [ -z "$container_id" ]; then
+  echo "No running Docker Compose containers found. Exiting."
+  exit 1
+fi
+
+# Extract project name from that container's label
+PROJECT_NAME=$(docker inspect "$container_id" \
+  --format '{{ index .Config.Labels "com.docker.compose.project" }}')
+
+if [ -z "$PROJECT_NAME" ]; then
+  echo "Unable to detect Docker Compose project name. Exiting."
+  exit 1
+fi
+
+echo "Detected Compose project: $PROJECT_NAME"
+
+while true; do
+  containers=$(docker ps --filter "label=com.docker.compose.project=$PROJECT_NAME" --format '{{.Names}}')
+
+  for container in $containers; do
+    if ! docker inspect -f '{{.State.Health.Status}}' "$container" >/dev/null 2>&1; then
+      continue
+    fi
+
+    status=$(docker inspect -f '{{.State.Health.Status}}' "$container")
+
+    if [ "$status" = "unhealthy" ]; then
+      echo "$(date): Container $container is unhealthy. Restarting entire Compose project: $PROJECT_NAME"
+      docker compose -p "$PROJECT_NAME" restart
+    fi
+  done
+
+  sleep 30
+done
+


### PR DESCRIPTION
My guacamole server seems to randomly break every day unless I add a watchdog to restart it periodically.