### PR TITLE
Updated deprecated Guacamole environment variables.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,10 +132,10 @@ services:
     - postgres
     environment:
       GUACD_HOSTNAME: guacd
-      POSTGRES_DATABASE: guacamole_db
-      POSTGRES_HOSTNAME: postgres
-      POSTGRES_PASSWORD: 'ChooseYourOwnPasswordHere1234'
-      POSTGRES_USER: guacamole_user
+      POSTGRESQL_DATABASE: guacamole_db
+      POSTGRESQL_HOSTNAME: postgres
+      POSTGRESQL_PASSWORD: 'ChooseYourOwnPasswordHere1234'
+      POSTGRESQL_USERNAME: guacamole_user
       RECORDING_SEARCH_PATH: /record
     image: guacamole/guacamole
     networks:


### PR DESCRIPTION
Fixes issues in latest guacamole/guacamole:1.6.0 which leads to a broken instance:

sudo docker logs guacamole_compose

WARNING: The "POSTGRES_USER" environment variable has been deprecated in favor of "POSTGRESQL_USERNAME". Please migrate your configuration when possible, as support for the older name may be removed in future releases.
WARNING: The "POSTGRES_" prefix for environment variables has been deprecated in favor of the "POSTGRESQL_" prefix. Please migrate your configuration when possible, as support for the older prefix may be removed in future releases.