### PR TITLE
Update of environment variables for guacamole to comply with changes made on version 1.5.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,10 +132,10 @@ services:
     - postgres
     environment:
       GUACD_HOSTNAME: guacd
-      POSTGRES_DATABASE: guacamole_db
-      POSTGRES_HOSTNAME: postgres
-      POSTGRES_PASSWORD: 'ChooseYourOwnPasswordHere1234'
-      POSTGRES_USER: guacamole_user
+      POSTGRESQL_DATABASE: guacamole_db
+      POSTGRESQL_HOSTNAME: postgres
+      POSTGRESQL_PASSWORD: 'ChooseYourOwnPasswordHere1234'
+      POSTGRESQL_USER: guacamole_user
       RECORDING_SEARCH_PATH: /record
     image: guacamole/guacamole
     networks:


### PR DESCRIPTION
In version 1.5.2 the environment variables for postgresql changed:

`POSTGRES_* renamed to POSTGRESQL_*`

source (at the very bottom of the list, section "Deprecation / Compatibility notes"): https://guacamole.apache.org/releases/1.5.2/